### PR TITLE
Correction files of all-signal version

### DIFF
--- a/utilities/current-pipeline/01-corrections/counties-multinomial-preprocessor-all-signals.Rmd
+++ b/utilities/current-pipeline/01-corrections/counties-multinomial-preprocessor-all-signals.Rmd
@@ -1,0 +1,279 @@
+---
+title: "County usa-facts confirmed case corrections with backfilling"
+author: "Delphi Group - Last run:"
+date: "`r format(Sys.time(), '%B %d, %Y')`"
+output:
+  html_document:
+    code_folding: hide
+params:
+  window_size: 14
+  start_date: NULL
+  sig_cut: 3
+  size_cut: 20
+  sig_consec: 2.25
+  outlier_start_date: "2020-03-01"
+  time_value_flag_date: "2020-11-22"
+  cache_data: FALSE
+  backfill_lag: 30
+  excess_cut: 0
+  write_RDS: TRUE
+  covidcast_data_source: !r c("usa-facts", "jhu-csse")
+  covidcast_signal: !r c("deaths_incidence_num","confirmed_incidence_num")
+  corrections_db_path: "./data_corrections-all-signals.sqlite"
+  editor_options: 
+  chunk_output_type: inline
+---
+
+```{r, message=FALSE, warning=FALSE}
+library(covidcast)
+library(dplyr)
+library(tidyr)
+library(lubridate)
+library(RcppRoll)
+library(cowplot)
+library(ggplot2)
+library(DT)
+library(ggforce)
+knitr::opts_chunk$set(warning = FALSE, message=FALSE, dev="CairoSVG")
+source("process-funs.R")
+source("corrections.R")
+attach(params)
+```
+
+Data retrieval
+```{r, cache=params$cache_data}
+
+county_data <- function(data.source) {
+  county_data <- list()
+  for (i in 1:length(data.source)) {
+    data <-  suppressMessages(
+        covidcast_signals(
+        data_source = data.source[i], 
+        covidcast_signal,
+        geo_type = "county", 
+        start_day = outlier_start_date)
+    county_data[[i]] <- aggregate_signals(data, format = "long") 
+  }
+  if (length(data.source) == 1) {
+    county_all = as.data.frame(county_data)
+  }
+  else{
+    county_all =  data.table::rbindlist(county_data)
+  }
+  return(county_all)
+}
+
+counties_all <- county_data(covidcast_data_source)
+```
+
+
+Data Wrangling notes:
+
+* Only counties with > 30 days' available data will be selected
+* Counties whose maximum confirmed_incidence_num <10 are filtered out in either data source.
+* Top 300 of counties sorted by total cases will be corrected
+
+```{r}
+todump <- counties_all %>% 
+  filter(signal == "confirmed_incidence_num")%>% 
+  group_by(data_source,geo_value) %>% 
+  summarise(
+    ava_value_count = sum(!is.na(value)),
+    case_sum = sum(value,na.rm = T),
+    max_case = max(value)
+    ) %>% 
+  filter(max_case>=10, 
+         ava_value_count>=30, 
+         as.numeric(geo_value) %% 1000 > 0) %>% 
+  arrange(desc(case_sum)) %>% top_n(300, wt=case_sum) 
+county_filtered <- subset(counties_all,counties_all$geo_value %in% todump$geo_value)
+```
+
+
+Since we would only implement `corrections_multinom_roll` on confirmed_incidence_num, therefore only rows with a signal "confirmed_incidence_num" will be flagged here.
+
+```{r calculate-roll-stats}
+df <- county_filtered %>% 
+  filter(signal == "confirmed_incidence_num") %>%
+  group_by(data_source,geo_value)  %>% mutate(
+  fmean = roll_meanr(value, window_size),
+  # smean = roll_mean(value, window_size, fill = NA),
+  fmedian = roll_medianr(value, window_size),
+  smedian = roll_median(value, window_size, fill = NA),
+  fsd = roll_sdr(value, window_size),
+  ssd = roll_sd(value, window_size,fill = NA),
+  fmad = roll_medianr(abs(value-fmedian), window_size,na.rm=TRUE),
+  smad = roll_median(abs(value-smedian), na.rm=TRUE),
+  ftstat = abs(value-fmedian)/fsd, # mad in denominator is wrong scale, 
+  ststat = abs(value-smedian)/ssd, # basically results in all the data flagged
+  flag = 
+    (abs(value) > size_cut & !is.na(ststat) & ststat > sig_cut ) | # best case
+    (is.na(ststat) & abs(value) > size_cut & !is.na(ftstat) & ftstat > sig_cut) | 
+      # use filter if smoother is missing
+    (value < -size_cut & !is.na(ststat) & !is.na(ftstat)), # big negative
+    #(fmean > 10 & fmean< 20 & value > 2*sig_cut*fmean)
+  flag = flag | # these allow smaller values to also be outliers if they are consecutive
+    (dplyr::lead(flag) & !is.na(ststat) & ststat > sig_consec) | 
+    (dplyr::lag(flag) & !is.na(ststat) & ststat > sig_consec) |
+    (dplyr::lead(flag) & is.na(ststat) & ftstat > sig_consec) |
+    (dplyr::lag(flag) & is.na(ststat) & ftstat > sig_consec),
+  # RI_daily_flag = (geo_value=="44007" & value!=0 & 
+  #                    lead(value,n=1L)!=0 & lead(value,n=2L)!=0 
+  #                  & lead(value,n=3L)!=0)
+  ##flag = flag & (time_value < ymd("2020-11-01") | value < -size_cut)
+  flag = flag & 
+    (time_value < ymd(time_value_flag_date) | value < -size_cut),
+  flag = flag | 
+    (time_value == "2020-11-20" & as.numeric(geo_value) %/% 1000 == 22)
+  #Louisiana backlog drop https://ldh.la.gov/index.cfm/newsroom/detail/5891
+  )
+
+county_filtered <- county_filtered %>% left_join(df,by = c("data_source","signal","geo_value","time_value","issue","lag","stderr","sample_size","dt","value"))
+
+county_filtered <-  county_filtered %>% 
+  mutate(FIP = substr(geo_value,1,2)) %>% 
+  mutate(state = names(STATE_TO_FIPS)[match(FIP,STATE_TO_FIPS)]) %>% 
+  select(-FIP) %>% relocate(state,.after=geo_value)
+```
+
+
+## Make corrections
+
+Now we use the "multinomial" smoother to backfill the excess of any flagged outliers. Some notes:
+
+* We use a new function `corrections_multinom_roll()` to do the backfill.
+* It backfills deterministicly rather than randomly.
+* It rounds alternate days up or down to try to avoid too much integers such that the sum is the excess.
+* Optionally allows for filling non-uniformly.
+
+
+```{r}
+# RI reports only weekly
+corrected_counties <- county_filtered %>% 
+  mutate(
+    # FIPS = as.numeric(geo_value),
+    excess = value - na_replace(smedian, fmedian),
+    excess = floor(excess - excess_cut*sign(excess)*na_replace(smad,fmad)),
+    flag_bad_RI = (state == "RI"  & value > 10 & lag(value) == 0),
+    corrected = corrections_multinom_roll(
+      value, value, flag_bad_RI, time_value, 7),
+    # flag_bad_VA =(geo_value == "51059"  && lag(value) > 0),
+    # corrected = corrections_multinom_roll(
+    #   value, value, flag_bad_VA, time_value, FIPS, 7),
+    corrected = corrections_multinom_roll(
+      corrected, excess, (flag & !flag_bad_RI), time_value, 
+      backfill_lag, 
+      reweight=function(x) exp_w(x, backfill_lag)),
+    corrected = evalforecast:::multinomial_roll_sum(corrected),
+    corrected = corrected + # imputes forward due to weekly releases
+      missing_future(state=="RI", time_value, excess, fmean)
+    )
+```
+
+
+## Visualize corrected counties
+
+```{r show-corrections, fig.height = 120, fig.width = 30, dev="CairoSVG"}
+simple_labs = covidcast::fips_to_name(unique(corrected_counties$geo_value))
+simple_labs = gsub(" County| city| Parish", "", simple_labs)
+sta = names(STATE_TO_FIPS)[match(substr(names(simple_labs), 1, 2), STATE_TO_FIPS)]
+nn = names(simple_labs)
+simple_labs = paste(simple_labs, sta)
+names(simple_labs) = nn
+
+
+corrected_counties %>% group_by(geo_value) %>% 
+  filter(any(flag == 'TRUE')) %>% 
+  dplyr::select(geo_value, time_value, value, corrected, flag) %>%
+  pivot_longer(value:corrected) %>%
+  ggplot(aes(time_value))+geom_line(aes(y=value, color=name))+
+  geom_point(
+    data = filter(corrected_counties, flag), 
+    aes(y=value), color="red")+ 
+  facet_wrap(~data_source + signal + geo_value, scales = "free", ncol = 5,
+             labeller = labeller(geo_value = simple_labs))+
+  theme_cowplot()+xlab("date")+
+  ylab(attributes(county_filtered)$metadata$signal)+
+  scale_color_viridis_d() + 
+  scale_x_date(date_breaks = "months" , date_labels = "%b")
+```
+
+## Show all corrected time points
+
+```{r}
+sum_check <- corrected_counties %>% 
+  group_by(data_source,signal,geo_value) %>%
+  summarise(original = sum(value, na.rm=TRUE),
+            corrected = sum(corrected, na.rm = TRUE)) %>% ungroup() %>%
+  mutate(diffs = abs(original-corrected)) %>%
+  filter(diffs > 1e-8) %>%
+  select(data_source,signal,geo_value, diffs)
+
+sum_check
+
+tosave <- corrected_counties %>% 
+  mutate(output = abs(corrected - value) > 0) %>%
+  filter(output) %>% ungroup() %>%
+  dplyr::select(data_source,signal,geo_value, time_value, value, corrected) %>%
+  transmute(
+    location=as.character(geo_value),
+    location_name=as.character(NA),
+    reference_date=as.Date(time_value), 
+    issue_date=as.Date(NA),
+    variable_name = paste(data_source, signal, sep = "_"),
+    value = as.double(value),
+    new_value = as.double(corrected),
+    correction_date = Sys.Date(),
+    description = as.character("")
+    ) %>%
+  filter(reference_date >= params$outlier_start_date) %>%
+  arrange(reference_date)
+
+
+corrected_counties %>% 
+  mutate(output = abs(corrected - value) > 0) %>%
+  filter(output) %>%
+  dplyr::select(data_source,signal,geo_value, time_value, value, corrected) %>%
+  transmute(data_source = data_source,
+            geo_value = geo_value,
+            signal = signal,
+            time_value=time_value, 
+            geo_value=geo_value,
+            orig_value = value,
+            replacement = corrected
+            ) %>%
+  datatable(
+    options = list(scrollX = TRUE, scrollY = "300px",paging = FALSE),
+    rownames = NULL) 
+```
+
+
+
+
+```{r eval=params$write_RDS}
+update_corrections(corrections_db_path, "county", tosave)
+```
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+

--- a/utilities/current-pipeline/01-corrections/states-multinomial-preprocessor-all-signals.Rmd
+++ b/utilities/current-pipeline/01-corrections/states-multinomial-preprocessor-all-signals.Rmd
@@ -1,0 +1,202 @@
+---
+title: "State death corrections with backfilling"
+author: "Delphi Group - Last run:"
+date: "`r format(Sys.time(), '%B %d, %Y')`"
+output:
+  html_document:
+    code_folding: hide
+params:
+  window_size: 14
+  start_date: "2020-03-01"
+  sig_cut: 3
+  size_cut: 20
+  sig_consec: 2.25
+  outlier_start_date: "2020-03-15"
+  time_value_flag_date: "2020-11-09"
+  cache_data: FALSE
+  backfill_lag: 30
+  covidcast_data_source: "jhu-csse"
+  covidcast_signal: !r c("deaths_incidence_num","confirmed_incidence_num")
+  corrections_db_path: "./data_corrections-all-signal.sqlite"
+  excess_cut: 0
+  write_RDS: TRUE
+---
+
+```{r setup, warning=FALSE, message=FALSE}
+library(covidcast)
+library(dplyr)
+library(tidyr)
+library(forcats)
+library(lubridate)
+library(RcppRoll)
+library(cowplot)
+library(ggplot2)
+library(DT)
+library(evalcast)
+knitr::opts_chunk$set(warning = FALSE, message=FALSE)
+source("process-funs.R")
+source("corrections.R")
+attach(params)
+```
+
+```{r grab-data, cache=params$cache_data}
+states <-  suppressMessages(
+  covidcast_signals(
+      data_source = covidcast_data_source, 
+      signal = covidcast_signal,
+      geo_type = "state", 
+      start_day = start_date)
+)
+
+# Aggregating signals, long format
+states_all <- aggregate_signals(states, format = "long") 
+```
+
+
+```{r calculate-roll-stats}
+states_all <- states_all %>% group_by(signal,geo_value) %>% mutate(
+  fmean = roll_meanr(value, window_size),
+  smean = roll_mean(value, window_size, fill = NA),
+  fmedian = roll_medianr(value, window_size),
+  smedian = roll_median(value, window_size, fill = NA),
+  fsd = roll_sdr(value, window_size),
+  ssd = roll_sd(value, window_size,fill = NA),
+  fmad = roll_medianr(abs(value-fmedian), window_size),
+  smad = roll_median(abs(value-smedian), window_size, fill=NA),
+  ftstat = abs(value-fmedian)/fsd, # mad in denominator is wrong scale, 
+  ststat = abs(value-smedian)/ssd, # basically results in all the data flagged
+  flag = 
+    (abs(value) > size_cut & !is.na(ststat) & ststat > sig_cut) | # best case
+    (is.na(ststat) & abs(value) > size_cut & !is.na(ftstat) & ftstat > sig_cut) | 
+    # use filter if smoother is missing
+    (value < -size_cut & (!is.na(ststat) | !is.na(ftstat))), # big negative
+  flag = flag | # these allow smaller values to also be outliers if they are consecutive
+    (dplyr::lead(flag) & !is.na(ststat) & ststat > sig_consec) | 
+    (dplyr::lag(flag) & !is.na(ststat) & ststat > sig_consec) |
+    (dplyr::lead(flag) & is.na(ststat) & ftstat > sig_consec) |
+    (dplyr::lag(flag) & is.na(ststat) & ftstat > sig_consec),
+  FIPS = as.numeric(STATE_TO_FIPS[toupper(geo_value)]),
+  #flag = flag & (time_value < ymd("2020-10-24") | value < -size_cut)  
+  flag = flag & (time_value < ymd(time_value_flag_date) | value < -size_cut)
+  #flag = flag & !(geo_value=="nc" & time_value > ymd("2020-10-22"))
+)
+```
+
+
+## Make corrections
+
+Now we use the "multinomial" smoother to backfill the excess of any flagged outliers. Some notes:
+  
+* We use a new function `corrections_multinom_roll()` to do the backfill.
+* It backfills randomly based on smoother as weights
+* Optionally allows for filling non-uniformly.
+* As of 10/4, we convolve with a linear decay over 30 days. 
+
+```{r}
+corrected_states = states_all %>% 
+  mutate(
+    state = toupper(geo_value),
+    # try using everything, not just the "excess"
+    excess = value,
+    # excess = value - na_replace(smedian, fmedian),
+    # excess = floor(excess - excess_cut*sign(excess)*na_replace(smad,fmad)),
+    # flag_big_ny = (geo_value == "ny" & time_value == ymd("2020-05-18")),
+    # corrected = corrections_multinom_roll(
+    #   value, excess, flag_big_ny, time_value, Inf, smedian,
+    #   reweight=function(x){ 
+    #     exp_w(x, as.numeric(ymd("2020-05-18")-ymd(start_date)))
+    #     }),
+    flag_bad_RI = (state == "RI"  & value > 0 & lag(value) == 0),
+    #flag_bad_NC = (state == "NC" & time_value > ymd("2020-10-22")),
+    corrected = corrections_multinom_roll(
+      value, value, flag_bad_RI, time_value, 7),
+    #c(32,30,13,13,41,34,38)),
+    corrected = corrections_multinom_roll(
+      corrected, excess, (flag & !flag_bad_RI ), time_value, 
+      backfill_lag, 
+      reweight=function(x) exp_w(x, backfill_lag)),
+    corrected = evalforecast:::multinomial_roll_sum(corrected),
+    corrected = corrected + # imputes forward due to weekly releases
+      missing_future(state=="RI", time_value, excess, fmean)
+      #missing_future(state=="WI", time_value, excess, fmedian)
+  )
+#corrected_states$corrected[corrected_states$state=="NC" & corrected_states$time_value > ymd("2020-10-22")] = c(32,30,13,13,41,34,38)
+```
+
+## Visualizations
+
+* These are states in which corrections are made
+* Yellow: original value; purple: corrected value; red dot: flagged outlier
+
+```{r show-corrections, fig.height = 60, fig.width = 10, dev="CairoSVG"}
+corrected_states %>% 
+  group_by(geo_value) %>% 
+  dplyr::select(geo_value, time_value, value, corrected, flag) %>%
+  pivot_longer(value:corrected) %>%
+  ggplot(aes(time_value)) + geom_line(aes(y=value,color=name)) +
+  geom_point(data = filter(corrected_states, flag), aes(y=value), color="red") +
+  facet_wrap(~signal + geo_value , scales = "free", ncol = 2) +
+  theme_cowplot() + xlab("date") + 
+  ylab(attributes(states)$metadata$signal) +
+  scale_color_viridis_d() + 
+  scale_x_date(date_breaks = "months" , date_labels = "%b")
+```
+
+## Show all corrected time points
+
+```{r}
+sum_check = corrected_states %>% 
+  group_by(signal,geo_value) %>%
+  summarise(original = sum(value, na.rm=TRUE),
+            corrected = sum(corrected, na.rm = TRUE)) %>% ungroup() %>%
+  mutate(diffs = abs(original-corrected)) %>%
+  filter(diffs > 1e-8) %>%
+  select(signal,geo_value, diffs)
+
+sum_check
+
+tosave <- corrected_states %>% 
+  mutate(output = abs(corrected - value) > 0) %>%
+  filter(output) %>% ungroup() %>%
+  dplyr::select(signal,geo_value, time_value, value, corrected, FIPS) %>%
+  transmute(
+    location_name = toupper(geo_value),
+    location = substr(FIPS, 1,2),
+    reference_date=as.Date(time_value), 
+    issue_date = as.Date(NA),
+    variable_name = paste(covidcast_data_source, signal, sep = "_"),
+    value = as.double(value),
+    new_value = as.double(corrected), 
+    correction_date = Sys.Date(),
+    description = as.character("")
+  ) %>%
+  filter(reference_date >= params$outlier_start_date) %>%
+  dplyr::relocate(location)
+
+corrected_states %>% 
+  mutate(output = abs(corrected - value) > 0) %>%
+  filter(output) %>%
+  dplyr::select(signal,geo_value, time_value, value, corrected, ftstat, ststat) %>%
+  transmute(signal = signal,
+            time_value=time_value, 
+            geo_value=geo_value,
+            orig_value = value,
+            replacement = corrected
+  ) %>%
+  datatable(
+    options = list(
+      scrollX = TRUE, scrollY = "300px",paging = FALSE),
+    rownames = NULL) 
+```
+
+```{r eval=params$write_RDS}
+update_corrections(corrections_db_path, "state", tosave)
+```
+
+
+
+
+
+
+
+


### PR DESCRIPTION
Add signal features are added for correction files at both state and county levels. 
1. [states-multinomial-preprocessor-all-signals.Rmd](https://github.com/yelselmiao/covid-19-forecast/blob/all_signals/utilities/current-pipeline/01-corrections/states-multinomial-preprocessor-all-signals.Rmd)

- Line 19: two signals used ("deaths_incidence_num" and "confirmed_incidence_num")
- Line 44:  `covidcast_signals` is used to catch multiple signals
- Line 52: aggregate signals into long form
- Line 138: facet_wrap by both signals and geo_value
- Line 149, 154, 161, 179: trivial changes to display signals 

2. [counties-multinomial-preprocessor-all-signals.Rmd](https://github.com/yelselmiao/covid-19-forecast/blob/all_signals/utilities/current-pipeline/01-corrections/counties-multinomial-preprocessor-all-signals.Rmd)

- Line 20, 21: vectorize data source and signals
- Line 46: write a function to aggregate data from data sources with multiple signals
- Line 78,79: filtering counties by the same logic but by two data sources
- Line 96：implement `corrections_multinom_roll` on confirmed_incidence_num
- Line 193: facet_wrap by data_source, signal, and geo_value
- Line 205, 217, and 236: trivial changes to the datatable.

