### PR TITLE
Add geo filtering to Reichlab formatter

### DIFF
--- a/utilities/zookeeper/R/reichlab-formatter.R
+++ b/utilities/zookeeper/R/reichlab-formatter.R
@@ -63,7 +63,7 @@ format_predictions_for_reichlab_submission <- function(predictions_cards,
     mutate(type = "point", quantile = NA)
 
   reichlab_df <- bind_rows(reichlab_quantile, reichlab_point) %>%
-    filter(.data$location %in% geo_values_to_filter)
+    filter(!.data$location %in% geo_values_to_filter)
   locs_to_reformat <- reichlab_df$location[nchar(reichlab_df$location) == 2L]
   reichlab_df$location[nchar(reichlab_df$location) == 2L] <-
     evalcast:::abbr_2_fips(locs_to_reformat)

--- a/utilities/zookeeper/R/reichlab-formatter.R
+++ b/utilities/zookeeper/R/reichlab-formatter.R
@@ -9,13 +9,16 @@
 #'
 #' @param predictions_cards data frame of predictions of the type returned by
 #'   evalcast. You must pass in a single df.
+#' @param geo_values_to_filter character string or list thereof of geo_values to exclude from the
+#'   final output.
 #'
 #' @return a tibble for conversion to csv
 #' @export
 #' @importFrom purrr map map_lgl map_int map2
 #' @importFrom dplyr bind_rows filter
 #' @importFrom assertthat assert_that
-format_predictions_for_reichlab_submission <- function(predictions_cards){
+format_predictions_for_reichlab_submission <- function(predictions_cards,
+                                                       geo_values_to_filter = NULL){
 
   # (A) Remove non-predictions
   assert_that(class(predictions_cards)[1] == "predictions_cards",
@@ -59,7 +62,8 @@ format_predictions_for_reichlab_submission <- function(predictions_cards){
     filter(evalcast:::find_quantile_match(.data$quantile, 0.5)) %>%
     mutate(type = "point", quantile = NA)
 
-  reichlab_df <- bind_rows(reichlab_quantile, reichlab_point)
+  reichlab_df <- bind_rows(reichlab_quantile, reichlab_point) %>%
+    filter(.data$location %in% geo_values_to_filter)
   locs_to_reformat <- reichlab_df$location[nchar(reichlab_df$location) == 2L]
   reichlab_df$location[nchar(reichlab_df$location) == 2L] <-
     evalcast:::abbr_2_fips(locs_to_reformat)

--- a/utilities/zookeeper/tests/testthat/test-reichlab-formatter.R
+++ b/utilities/zookeeper/tests/testthat/test-reichlab-formatter.R
@@ -1,0 +1,86 @@
+test_that("format_predictions_for_reichlab_submission works", {
+    pcard <- tibble(
+      ahead = rep(c(1, 2, 3), each = 5),
+      geo_value = "pa",
+      quantile = rep(c(0.1, 0.4, 0.5, 0.6, 0.9), 3),
+      value = seq(1, 15),
+      forecaster = "a",
+      forecast_date = as.Date("2020-01-02"),
+      data_source = "source",
+      signal = rep(c("confirmed_incidence_num", "confirmed_incidence_num", "deaths_incidence_num"),
+                   each = 5),
+      target_end_date = rep(as.Date(c("2020-01-09", "2020-01-16", "2020-01-23")), each = 5),
+      incidence_period = "epiweek"
+    )
+    class(pcard) <- c("predictions_cards", class(pcard))
+
+    out <- format_predictions_for_reichlab_submission(pcard)
+    expect_equal(names(out), c("location", "forecast_date", "quantile", "value", "target",
+                               "target_end_date", "type"))
+    expect_equal(out$location, rep("42", 14))
+    expect_equal(out$forecast_date, rep(as.Date("2020-01-02"), 14))
+    expect_equal(out$quantile, c(0.1, 0.5, 0.9, 0.1, 0.5, 0.9, 0.1, 0.4, 0.5, 0.6, 0.9, NA, NA, NA))
+    expect_equal(out$value, c(1, 3, 5, 6, 8, 10, 11, 12, 13, 14, 15, 3, 8, 13))
+    expect_equal(out$target, c("1 wk ahead inc case",
+                               "1 wk ahead inc case",
+                               "1 wk ahead inc case",
+                               "2 wk ahead inc case",
+                               "2 wk ahead inc case",
+                               "2 wk ahead inc case",
+                               "3 wk ahead inc death",
+                               "3 wk ahead inc death",
+                               "3 wk ahead inc death",
+                               "3 wk ahead inc death",
+                               "3 wk ahead inc death",
+                               "1 wk ahead inc case",
+                               "2 wk ahead inc case",
+                               "3 wk ahead inc death"
+                               ))
+    expect_equal(out$target_end_date, as.Date(c("2020-01-09", "2020-01-09", "2020-01-09",
+                                                "2020-01-16", "2020-01-16", "2020-01-16",
+                                                "2020-01-23", "2020-01-23", "2020-01-23",
+                                                "2020-01-23", "2020-01-23", "2020-01-09",
+                                                "2020-01-16", "2020-01-23")))
+    expect_equal(out$type, c(rep("quantile", 11), rep("point", 3)))
+})
+
+test_that("format_predictions_for_reichlab_submission filters locations", {
+    pcard <- tibble(
+      ahead = rep(c(1, 2, 3), each = 5),
+      geo_value = rep(c("al", "pa", "wy"), each = 5),
+      quantile = rep(c(0.1, 0.4, 0.5, 0.6, 0.9), 3),
+      value = seq(1, 15),
+      forecaster = "a",
+      forecast_date = as.Date("2020-01-02"),
+      data_source = "source",
+      signal = rep(c("confirmed_incidence_num", "confirmed_incidence_num", "deaths_incidence_num"),
+                   each = 5),
+      target_end_date = rep(as.Date(c("2020-01-09", "2020-01-16", "2020-01-23")), each = 5),
+      incidence_period = "epiweek"
+    )
+    class(pcard) <- c("predictions_cards", class(pcard))
+    out <- format_predictions_for_reichlab_submission(pcard, "pa")
+
+    expect_equal(names(out), c("location", "forecast_date", "quantile", "value", "target",
+                               "target_end_date", "type"))
+    expect_equal(out$location, c("01", "01", "01", "56", "56", "56", "56", "56", "01", "56"))
+    expect_equal(out$forecast_date, rep(as.Date("2020-01-02"), 10))
+    expect_equal(out$quantile, c(0.1, 0.5, 0.9, 0.1, 0.4, 0.5, 0.6, 0.9, NA, NA))
+    expect_equal(out$value, c(1, 3, 5, 11, 12, 13, 14, 15, 3, 13))
+    expect_equal(out$target, c("1 wk ahead inc case",
+                               "1 wk ahead inc case",
+                               "1 wk ahead inc case",
+                               "3 wk ahead inc death",
+                               "3 wk ahead inc death",
+                               "3 wk ahead inc death",
+                               "3 wk ahead inc death",
+                               "3 wk ahead inc death",
+                               "1 wk ahead inc case",
+                               "3 wk ahead inc death"
+                               ))
+    expect_equal(out$target_end_date, as.Date(c("2020-01-09", "2020-01-09", "2020-01-09",
+                                                "2020-01-23", "2020-01-23", "2020-01-23",
+                                                "2020-01-23", "2020-01-23", "2020-01-09",
+                                                "2020-01-23")))
+    expect_equal(out$type, c(rep("quantile", 8), rep("point", 2)))
+})


### PR DESCRIPTION
Add an extra argument to `format_predictions_for_reichlab_submission()` of geo values to remove for the final submission.  Also add tests for the function. 