### PR TITLE
revise parameter scripts

### DIFF
--- a/utilities/QA-reports/anteater.Rmd
+++ b/utilities/QA-reports/anteater.Rmd
@@ -3,10 +3,6 @@ title: "Anteater Trajectory Plots"
 author: "Delphi County Cases, Forecast on:"
 date: "`r format(Sys.time(), '%B %d, %Y')`"
 output: html_document
-params:
-  forecast_date: !r Sys.getenv("FORECAST_DATE")
-  today: !r Sys.getenv("TODAY")
-  output_dir: "/mnt"
 ---
 
 ```{r setup, include=FALSE, echo=FALSE}
@@ -17,8 +13,8 @@ library(tidyverse)
 source("production_params.R")
 
 anteater  <- readRDS(file.path(
-  params$output_dir, state_output_subdir,
-  sprintf("predictions_for_%s.RDS", params$forecast_date)))
+  output_dir, state_output_subdir,
+  sprintf("predictions_for_%s.RDS", forecast_date)))
 ```
 
 ## Trajectory plots
@@ -30,36 +26,21 @@ anteater  <- readRDS(file.path(
 
 ```{r, fig.height = 80, fig.width = 30, dev="CairoSVG", echo=FALSE}
 # Grab corrected data
-state_params <- zookeeper::default_state_params(data_source = anteater_signals$data_source,
-                                                signal = anteater_signals$signal,
-                                                geo_type = anteater_signals$geo_type)
-
-##aad <- zookeeper::make_aardvark_corrector(params = state_params)
-
-aad <- zookeeper::make_state_corrector(
-  manual_flags = tibble(data_source = "jhu-csse",
-                        signal = c(rep("deaths_incidence_num", 3),
-                                   "confirmed_incidence_num"),
-                        geo_value = c("va","ky","ok","ok"),
-                        time_value = list(
-                          seq(lubridate::ymd("2021-02-21"), lubridate::ymd("2021-03-04"), by = 1),
-                          lubridate::ymd(c("2021-03-18","2021-03-19")),
-                          lubridate::ymd("2021-04-07"),
-                          lubridate::ymd("2021-04-07")),
-                        max_lag = rep(90, 4)))
-
-corrected <- suppressMessages(covidcast::covidcast_signal(
-  ##anteater_signals$data_source, anteater_signals$signal[1],
-  "jhu-csse", "deaths_incidence_num", 
-  start_day = ymd(params$today) - days(x = 90), 
+corrected <- suppressMessages(
+  covidcast::covidcast_signal(
+    anteater_signals$data_source, 
+    anteater_signals$signal[1],
+    start_day = ymd(today) - days(x = qa_lookback), 
   geo_type = "state")) %>% 
-  aad()  # make corrections
+  state_corrector()
+
 corrected <- corrected[[1]] %>% evalcast:::sum_to_epiweek()
 
 # setup the plot and join corrections to the truth
 pd <- evalcast:::setup_plot_trajectory(
   anteater, geo_type = "state",
-  start_day = lubridate::ymd(params$today) - lubridate::days(x = 90))
+  start_day = lubridate::ymd(today) - lubridate::days(x = qa_lookback)
+  
 pd$truth_df <- left_join(
   pd$truth_df, corrected, 
   by = c("geo_value" = "geo_value", "target_end_date" = "time_value"))

--- a/utilities/QA-reports/zebra.Rmd
+++ b/utilities/QA-reports/zebra.Rmd
@@ -38,7 +38,7 @@ corrected <- suppressMessages(covidcast::covidcast_signal(
   zebra_signals$data_source[1], zebra_signals$signal[1],
   start_day = lubridate::ymd(today) - lubridate::days(x = qa_lookback), 
   geo_type = "county")) %>% 
-  zyz()  # make corrections
+  county_corrector()  # make corrections
 corrected <- corrected[[1]] %>% evalcast:::sum_to_epiweek()
 
 # setup the plot and join corrections to the truth

--- a/utilities/QA-reports/zebra.Rmd
+++ b/utilities/QA-reports/zebra.Rmd
@@ -3,10 +3,6 @@ title: "Zebra Trajectory Plots"
 author: "Delphi County Cases, Forecast on:"
 date: "`r format(Sys.time(), '%B %d, %Y')`"
 output: html_document
-params:
-  forecast_date: !r Sys.getenv("FORECAST_DATE")
-  today: !r Sys.getenv("TODAY")
-  output_dir: "/mnt"
 ---
 
 ```{r setup, include=FALSE, echo=FALSE, message=FALSE}
@@ -17,8 +13,8 @@ library(tidyverse)
 source("production_params.R")
 
 zebra <- readRDS(file.path(
-  params$output_dir, county_output_subdir,
-  sprintf("predictions_for_%s.RDS", params$forecast_date)))
+  output_dir, county_output_subdir,
+  sprintf("predictions_for_%s.RDS", forecast_date)))
 
 simple_labs <- function(geo_value) {
   sl <- covidcast::fips_to_name(geo_value)
@@ -37,13 +33,10 @@ simple_labs <- function(geo_value) {
 
 ```{r, fig.height = 120, fig.width = 30, dev="CairoSVG", echo=FALSE, message=FALSE}
 # Grab corrected data
-county_params  <- zookeeper::default_county_params(data_source = zebra_signals$data_source)
-zyz <- zookeeper::make_zyzzyva_corrector(params = county_params)
 
 corrected <- suppressMessages(covidcast::covidcast_signal(
   zebra_signals$data_source[1], zebra_signals$signal[1],
-##  "jhu-csse","confirmed_incidence_num", 
-  start_day = lubridate::ymd(params$today) - lubridate::days(x = 90), 
+  start_day = lubridate::ymd(today) - lubridate::days(x = qa_lookback), 
   geo_type = "county")) %>% 
   zyz()  # make corrections
 corrected <- corrected[[1]] %>% evalcast:::sum_to_epiweek()

--- a/utilities/production_params.R
+++ b/utilities/production_params.R
@@ -3,37 +3,108 @@
 ## One place for all parameters used by all production scripts (production_script.R) and
 ## and also markdowns (anteater.Rmd zebra.Rmd)
 
+
+# Common parameters -------------------------------------------------------
+
 forecast_date <- lubridate::ymd(Sys.getenv("FORECAST_DATE"))
 today  <- lubridate::ymd(Sys.getenv("TODAY"))
 ##output_dir  <- Sys.getenv("OUTPUT_DIR")
 ## We can fix this at /mnt
 output_dir  <- "/mnt"
-
+aheads  <- 1:4
 state_output_subdir  <- "state-output"
 county_output_subdir <- "county-output"
+qa_lookback <- 60 # how far back do we show actual data on the QA report?
+n_counties <- 200 # we predict the top 200 counties
 
-aheads  <- 1:4
 
-## Signals used by various forecasters
+
+
+# Signals used by the various forecasters ---------------------------------
+
 ## Here is where you change the signals if one or the other is not available.
-forecaster_signals <- list(
-  anteater = dplyr::tibble(data_source = "jhu-csse",
-                           signal = c("deaths_incidence_num",
-                                      "confirmed_incidence_num"),
-                           start_day = animalia::grab_start_day(aheads, 28, 14, "epiweek")(forecast_date),
-                           geo_type = "state"),
-  zebra = dplyr::tibble(data_source = c("jhu-csse",
-                                        ## "usa-facts",
-                                        "fb-survey",
-                                        "doctor-visits"),
-                        signal = c("confirmed_incidence_num",
-                                   ## "deaths_incidence_num",
-                                   "smoothed_hh_cmnty_cli",
-                                   "smoothed_cli"),
-                        start_day = animalia::grab_start_day(aheads, 28, 28, "epiweek")(forecast_date),
-                        geo_type = "county")
+anteater_signals <- dplyr::tibble( # state death forecaster
+  data_source = "jhu-csse",
+  signal = c("deaths_incidence_num", "confirmed_incidence_num"),
+  start_day = animalia::grab_start_day(aheads, 28, 14, "epiweek")(forecast_date),
+  geo_type = "state")
+
+
+zebra_signals <- dplyr::tibble( # county case forecaster
+  data_source = c("jhu-csse",
+                  ## "usa-facts",
+                  "fb-survey",
+                  "doctor-visits"),
+  signal = c("confirmed_incidence_num", "smoothed_hh_cmnty_cli", "smoothed_cli"),
+  start_day = animalia::grab_start_day(aheads, 28, 28, "epiweek")(forecast_date),
+  geo_type = "county")
+
+
+
+# State specific sets -----------------------------------------------------
+
+state_corrections_params <- zookeeper::default_state_params(
+  # many other options, see the function documentation
+  data_source = anteater_signals$data_source,
+  signal = anteater_signals$signal,
+  geo_type = anteater_signals$geo_type)
+
+state_corrector <- zookeeper::make_state_corrector(
+  params = state_corrections_params,
+  # data, locations, times to do special correction processing
+  manual_flags = tibble::tibble(
+    data_source = "jhu-csse",
+    signal = c(rep("deaths_incidence_num", 3), "confirmed_incidence_num"),
+    geo_value = c("va","ky","ok","ok"),
+    time_value = list(
+      seq(lubridate::ymd("2021-02-21"), lubridate::ymd("2021-03-04"), by = 1),
+      lubridate::ymd(c("2021-03-18","2021-03-19")),
+      lubridate::ymd("2021-04-07"),
+      lubridate::ymd("2021-04-07")),
+    max_lag = rep(90, 4)) # how far do we back distribute these spikes?
+  )
+
+state_forecaster_args <- list(
+  ahead = aheads,
+  lags = c(0,7,14),
+  tau = evalcast::covidhub_probs(), # 23 quantiles
+  lambda = 0, # no regularization or CV
+  lp_solver = "gurobi", # can remove if no license
+  noncross = TRUE, # takes a bit longer, but not much
+  featurize = animalia::make_state_7dav_featurizer(), # has no arguments
+  verbose = TRUE,
+  save_wide_data = file.path(output_dir, state_output_subdir),
+  save_trained_models = file.path(output_dir, state_output_subdir)
 )
 
-## No changes below
-anteater_signals  <- forecaster_signals[["anteater"]]
-zebra_signals  <- forecaster_signals[["zebra"]]
+
+# County specific sets ----------------------------------------------------
+
+county_corrections_params  <- zookeeper::default_county_params(
+  data_source = zebra_signals$data_source,
+  signal = zebra_signals$signals[1] # only correct cases
+)
+
+county_corrector  <- zookeeper::make_zyzzyva_corrector(params = county_corrections_params)
+
+prob_type <- ifelse(zebra_signals$signals[1] == "confirmed_incidence_num",
+                    "inc_case", "standard")
+
+
+county_forecaster_args <- list(
+  ahead = aheads,
+  lags = list(c(0, 1, 2, seq(3, 21, 3)), seq(3,28,7), seq(3,28,7)), 
+  tau = evalcast::covidhub_probs(type = prob_type), # only 7 quantiles for inc_cases
+  lambda = 0,
+  lp_solver = "gurobi",
+  noncross = TRUE,
+  featurize = animalia::make_county_7dav_featurizer(
+    response_data_source = zebra_signals$data_source[1],
+    response_signal = zebra_signals$signal[1],
+    n_locations = n_counties
+  ),
+  verbose = TRUE,
+  save_wide_data = file.path(output_dir, county_output_subdir),
+  save_trained_models = file.path(output_dir, county_output_subdir)
+)
+

--- a/utilities/production_script.R
+++ b/utilities/production_script.R
@@ -33,42 +33,16 @@ library(tidyverse)
 
 cat("Running States\n")
 
-aheads  <- 1:4
 
 ## make_aardvark_corrector below uses the signals defaults. Arrange to use the parameter
-anteater_signals  <- forecaster_signals[["anteater"]]
-state_params <- zookeeper::default_state_params(data_source = anteater_signals$data_source,
-                                                signal = anteater_signals$signal,
-                                                geo_type = anteater_signals$geo_type)
-aa_corrector <- zookeeper::make_state_corrector(
-                               manual_flags = tibble(data_source = "jhu-csse",
-                                                     signal = c(rep("deaths_incidence_num", 3),
-                                                                "confirmed_incidence_num"),
-                                                     geo_value = c("va","ky","ok","ok"),
-                                                     time_value = list(
-                                                         seq(lubridate::ymd("2021-02-21"), lubridate::ymd("2021-03-04"), by = 1),
-                                                         lubridate::ymd(c("2021-03-18","2021-03-19")),
-                                                         lubridate::ymd("2021-04-07"),
-                                                         lubridate::ymd("2021-04-07")),
-                                                     max_lag = rep(90, 4)))
 
-state_forecaster_args <- list(
-  ahead = aheads,
-  lags = c(0,7,14),
-  tau = evalcast::covidhub_probs(),
-  lambda = 0,
-  featurize = animalia::make_state_7dav_featurizer(),
-  verbose = TRUE,
-  save_wide_data = file.path(output_dir, state_output_subdir),
-  save_trained_models = file.path(output_dir, state_output_subdir)
-)
 state_predictions <- evalcast::get_predictions(
   forecaster = animalia::production_forecaster,
   name_of_forecaster = "anteater",
   signals = anteater_signals,
   forecast_dates = forecast_date,
   incidence_period = "epiweek",
-  apply_corrections = aa_corrector,
+  apply_corrections = state_corrector,
   forecaster_args = state_forecaster_args
 )
 warnings()
@@ -77,33 +51,22 @@ warnings()
 cat("Writing State results\n")
 ## Write result
 saveRDS(state_predictions,
-        file = file.path(output_dir, state_output_subdir,
-                         sprintf("predictions_for_%s.RDS", forecast_date)))
+        file = file.path(
+          output_dir, 
+          state_output_subdir,
+          sprintf("predictions_for_%s.RDS", forecast_date)
+        ))
 
 cat("Running Counties\n")
 
 
-zebra_signals  <- forecaster_signals[["zebra"]]
-county_params  <- zookeeper::default_county_params(data_source = zebra_signals$data_source)
-zz_corrector  <- zookeeper::make_zyzzyva_corrector(params = county_params)
-
-county_forecaster_args <- list(
-  ahead = aheads,
-  lags = list(c(0, 1, 2, seq(3, 21, 3)), seq(3,28,7), seq(3,28,7)), # Lags
-  tau = evalcast::covidhub_probs(type = "inc_case"),
-  lambda = 0,
-  featurize = animalia::make_county_7dav_featurizer(),
-  verbose = TRUE,
-  save_wide_data = file.path(output_dir, county_output_subdir),
-  save_trained_models = file.path(output_dir, county_output_subdir)
-)
 county_predictions <- evalcast::get_predictions(
   forecaster = animalia::production_forecaster,
   name_of_forecaster = "zebra",
   signals = zebra_signals,
   forecast_dates = forecast_date,
   incidence_period = "epiweek",
-  apply_corrections = zz_corrector,
+  apply_corrections = county_corrector,
   forecaster_args = county_forecaster_args
 )
 warnings()
@@ -118,14 +81,16 @@ saveRDS(county_predictions,
 cat("Running QA for States\n")
 
 ## Render the QA report
-rmarkdown::render(input = "anteater.Rmd", output_file = sprintf("anteater_%s.html", forecast_date),
+rmarkdown::render(input = "anteater.Rmd", 
+                  output_file = sprintf("anteater_%s.html", forecast_date),
                   output_dir = file.path(output_dir, state_output_subdir))
 
 cat("Done with States\n")
 cat("Running QA for Counties\n")
 
 ## Render the QA report
-rmarkdown::render(input = "zebra.Rmd", output_file = sprintf("zebra_%s.html", forecast_date),
+rmarkdown::render(input = "zebra.Rmd", 
+                  output_file = sprintf("zebra_%s.html", forecast_date),
                   output_dir = file.path(output_dir, county_output_subdir))
 
 cat("Done with Counties\n")
@@ -134,10 +99,10 @@ cat("Combine submission files")
 combined <- bind_rows(state_predictions, county_predictions)
 combined <- zookeeper::format_predictions_for_reichlab_submission(combined)
 
-readr::write_csv(combined,
-                 file = file.path(
-                   output_dir,
-                   sprintf("%s-CMU-TimeSeries.csv", forecast_date)))
+readr::write_csv(
+  combined,
+  file = file.path(output_dir, sprintf("%s-CMU-TimeSeries.csv", forecast_date))
+)
 
 ## Save session info
 sessionInfo()


### PR DESCRIPTION
1. Moved all tunable parameters out of `production_script.R` and into `production_params.R`. Added comments throughout, added the `lp_solver = "gurobi"` argument and turned on `noncross = TRUE`.
2. Some readablity changes inside `production_script.R`.
3. Revised QA reports to depend completely on `production_params.R`. This means moving the RMD parameters out of the yml and using those set in there. It also means using the already built correctors.
4. Note that the "corrector" functions were renamed to be state/county rather than `aa_corrector()` and `zz_corrector()`.