### PR TITLE
Move sample prodrun time to 10:30am

### DIFF
--- a/utilities/crontab.sh
+++ b/utilities/crontab.sh
@@ -1,3 +1,3 @@
 SHELL=/bin/bash
 GITHUB_PAT=<GITHUB_PAT here>
-40 14 * * * (cd <production_dir> && source ./production_env.sh && ./production_run.sh >> production_run_${TODAY}.log 2>&1)
+30 10 * * * (cd <production_dir> && source ./production_env.sh && ./production_run.sh >> production_run_${TODAY}.log 2>&1)


### PR DESCRIPTION
The server is in the ETZ in the Americas and its crontab is running using local time.

This change will likely not be automatically deployed; check if the server's crontab will need to be adjusted to match this commit!