### PR TITLE
fix a bug when df_list has length 1

### DIFF
--- a/forecasters/animalia/R/lag_processor.R
+++ b/forecasters/animalia/R/lag_processor.R
@@ -13,7 +13,8 @@
 #' @param nsigs Number of signals.
 #' 
 #' @return A list of length `nsigs`, with each element being the vector of
-#' (non-positive) lags associated with each signal.
+#' (non-positive) lags associated with each signal. When `nsigs` is 1, 
+#' returns the vector of lags for that signal.
 lag_processor <- function(lags, nsigs){
   assert_that(all(unlist(lags) >= 0), msg = "All lags must be nonnegative.")
   if (!is.list(lags)) {
@@ -25,5 +26,7 @@ lag_processor <- function(lags, nsigs){
                   "of signals."))
   }
   dt <- lapply(lags, "-")
+  if(length(dt)==1)
+    dt = unlist(dt)
   return(dt)
 }

--- a/forecasters/animalia/R/production_forecaster.R
+++ b/forecasters/animalia/R/production_forecaster.R
@@ -145,7 +145,10 @@ production_forecaster <- function(df_list,
   dt <- lag_processor(lags, nsigs)
   ahead_in_days <- purrr::map_dbl(
     ahead,  ~evalcast::get_target_ahead(forecast_date, incidence_period, .x))
-  dt[[1]] <- c(dt[[1]], ahead_in_days) 
+  if(class(dt) != 'list')
+    dt <- c(dt, ahead_in_days) 
+  else
+    dt[[1]] <- c(dt[[1]], ahead_in_days) 
   
   # -------------------------------
   # 1. data transformations, and saving


### PR DESCRIPTION
The lag_processor will return a list even when `df_list` has length 1, which can cause problems since other parts of the codes need df_list to be a dataframe with single signal.  This pull request is just to fix this small bug.